### PR TITLE
Fix `sudo` for ScientificLinux

### DIFF
--- a/Vagrant/Vagrantfile
+++ b/Vagrant/Vagrantfile
@@ -389,7 +389,7 @@ Vagrant.configure("2") do |config|
   config.ssh.forward_x11 = true
 
   # Change the `sudo` command.
-  config.ssh.sudo_command = "sudo -H %c"
+  config.ssh.sudo_command = "sudo %c"
 
   # VirtualBox settings
   config.vm.provider :virtualbox do |vb|

--- a/Vagrant/Vagrantfile
+++ b/Vagrant/Vagrantfile
@@ -388,6 +388,9 @@ Vagrant.configure("2") do |config|
   # Enable x11 forwarding (as if using ssh -X)
   config.ssh.forward_x11 = true
 
+  # Change the `sudo` command.
+  config.ssh.sudo_command = "sudo -H %c"
+
   # VirtualBox settings
   config.vm.provider :virtualbox do |vb|
     # Don't boot with headless mode


### PR DESCRIPTION
This changes the `sudo` command used by `vagrant` as mentioned in this issue ( https://github.com/mitchellh/vagrant/issues/6018#issuecomment-141080589 ). As a result, it appears that guest additions properly work again.
